### PR TITLE
Fixed CONVERT_TIME ports

### DIFF
--- a/DAC-ADC AD5764-AD7734/AD7734_AD5764_synchronized_DAC-ADC_v4.ino
+++ b/DAC-ADC AD5764-AD7734/AD7734_AD5764_synchronized_DAC-ADC_v4.ino
@@ -125,7 +125,25 @@ std::vector<int> listOfChannels(byte DB) // Returns the list of channels to writ
 
 void writeADCConversionTime(std::vector<String> DB)
 {
-  int adcChannel=DB[1].toInt();
+
+  int adcChannel;
+  switch(DB[1].toInt()){
+    case 0:
+    adcChannel = 1;
+    break;
+    case 1:
+    adcChannel = 3;
+    break;
+    case 2:
+    adcChannel = 0;
+    break;
+    case 3:
+    adcChannel = 2;
+    break;
+
+    default:  
+    break;
+  }
   byte cr;
 
   byte fw = ((byte)((DB[2].toInt()*6.144-249)/128))|128;


### PR DESCRIPTION
Thanks for sharing your work, this was very helpful to us!

Just a little fix that I found, your documentation doesn't specify that the "CONVERT_TIME" operation require 2 arguments, and the first argument is the port that should be "Switch-Case"d like I did in the Arduino code.
